### PR TITLE
Correct architectures values in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Allows using (multiple) delays without blocking code execution. Arduino
 paragraph=During the delay, the code execution is continued. We can use multiple delays simultaneously and independent of each other.
 category=Timing
 url=https://github.com/avandalen/VirtualDelay
-architectures=atmelavr, atmelsam
+architectures=avr, sam
 


### PR DESCRIPTION
The previous `architectures` values cause warnings such as:
```
WARNING: library VirtualDelay claims to run on (atmelavr, atmelsam) architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).
```